### PR TITLE
Insert noarch: python in meta.yaml, fix flake8 and pre-commit error

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,7 @@ repos:
     rev: v4.6.0
     hooks:
       - id: check-yaml
+        exclude: '{{ cookiecutter.module_name }}/meta.yaml'
       - id: end-of-file-fixer
       - id: trailing-whitespace
         exclude: '\.(rst|txt)$'

--- a/test_utils.py
+++ b/test_utils.py
@@ -27,7 +27,13 @@ p.expect("project_short_description .*")
 p.sendline("Shared utilities for diffpy packages.")
 
 p.expect("project_full_description .*")
-p.sendline("The diffpy.utils package provides functions for extracting array data from variously formatted text files and wx GUI utilities used by the PDFgui program. The package also includes an interpolation function based on the Whittaker-Shannon formula that can be used to resample a PDF or other profile function over a new grid.")
+p.sendline(
+    "The diffpy.utils package provides functions for extracting array data "
+    "from variously formatted text files and wx GUI utilities used by the "
+    "PDFgui program. The package also includes an interpolation function "
+    "based on the Whittaker-Shannon formula that can be used to resample "
+    "a PDF or other profile function over a new grid."
+)
 
 p.expect("license_file .*")
 p.sendline("LICENSE.txt")

--- a/{{ cookiecutter.module_name }}/meta.yaml
+++ b/{{ cookiecutter.module_name }}/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   preserve_egg_dir: true
-  noarch: true
+  noarch: python
   number: 0
   script: python -m pip install --no-deps --ignore-installed .
 

--- a/{{ cookiecutter.module_name }}/meta.yaml
+++ b/{{ cookiecutter.module_name }}/meta.yaml
@@ -12,6 +12,7 @@ source:
 
 build:
   preserve_egg_dir: true
+  noarch: true
   number: 0
   script: python -m pip install --no-deps --ignore-installed .
 

--- a/{{ cookiecutter.module_name }}/run_test.py
+++ b/{{ cookiecutter.module_name }}/run_test.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 import importlib
-import sys
 from pathlib import Path
 
 import pytest


### PR DESCRIPTION
I was requested by @sbillinge  to make a change. 

`noarch: true` means the package is designed to be platform-independent and can be installed on any operating system that supports the package manager.