### PR TITLE
Do not use jinja for SHA in meta.yaml

### DIFF
--- a/{{ cookiecutter.module_name }}/meta.yaml
+++ b/{{ cookiecutter.module_name }}/meta.yaml
@@ -1,6 +1,5 @@
 {{ "{%- set name =" | safe }} "{{ cookiecutter.module_name }}" {{ "-%}" | safe }}
 {{ "{%- set version =" | safe }} "{{ cookiecutter.version }}" {{ "-%}" | safe }}
-{{ "{%- set sha256 = \"GENERATE_SHA\" -%}" | safe }}
 
 package:
   name: {{ "{{ name|lower }}" | safe }}
@@ -8,7 +7,7 @@ package:
 
 source:
   url: GENERATE_SOURCE
-  sha256: {{ "{{ sha256 }}" | safe }}
+  sha256: {{ "GENERATE_SHA" | safe }}
 
 build:
   preserve_egg_dir: true


### PR DESCRIPTION
As suggested here in https://github.com/conda-forge/staged-recipes/pull/27265#discussion_r1736210779,

jinja templating is no longer used for `SHA` for it is being used only once as well.


## Test result

I tested locally by running `cookiecutter .` The following is generated using `diffpy.snmf` with v0.1.0,

```
{%- set name = "diffpy.snmf" -%}
{%- set version = "0.1.0" -%}

package:
  name: {{ name|lower }}
  version: {{ version }}

source:
  url: https://pypi.io/packages/source/d/diffpy_snmf/diffpy_snmf-{{ version }}.tar.gz
  sha256: 2903bd7d9df588b35bd45bc07ea745c69fb281fb774beef8af645cebcb980b7c
```

I 