### PR TITLE
Include pytest, pip list, pip check, and git-versioning, remove import tests

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -9,10 +9,9 @@
     "license_file": "LICENSE.rst",
     "recipe_maintainers": "sbillinge,",
     "build_requirements": "",
-    "host_requirements": "python >=3.10, setuptools, pip,",
-    "runtime_requirements": "python >=3.10, setuptools, numpy,",
-    "testing_requirements": "pytest,",
-    "test_package_imports": "{{ cookiecutter.repo_name }},",
+    "host_requirements": "python >=3.10, setuptools, setuptools-git-versioning >=2.0, pip,",
+    "runtime_requirements": "python >=3.10, numpy,",
+    "testing_requirements": "pip, pytest,",
     "_copy_without_render": [
         "*.html",
         "*.js",

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -64,7 +64,7 @@ with open(meta_yml_path, 'r') as mfile:
 
     # Add the testing requirements
     mfile_txt = add_list("{{ cookiecutter.testing_requirements }}", "GENERATE_TEST_REQUIREMENTS", mfile_txt)
-    
+
     # Add the maintainers
     mfile_txt = add_list("{{ cookiecutter.recipe_maintainers }}", "GENERATE_MAINTAINERS", mfile_txt)
 

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -62,12 +62,9 @@ with open(meta_yml_path, 'r') as mfile:
     # Add the runtime requirements
     mfile_txt = add_list("{{ cookiecutter.runtime_requirements }}", "GENERATE_RUN_REQUIREMENTS", mfile_txt)
 
-    # Add the imports to test
-    mfile_txt = add_list("{{ cookiecutter.test_package_imports }}", "GENERATE_IMPORTS", mfile_txt)
-
     # Add the testing requirements
     mfile_txt = add_list("{{ cookiecutter.testing_requirements }}", "GENERATE_TEST_REQUIREMENTS", mfile_txt)
-
+    
     # Add the maintainers
     mfile_txt = add_list("{{ cookiecutter.recipe_maintainers }}", "GENERATE_MAINTAINERS", mfile_txt)
 

--- a/{{ cookiecutter.module_name }}/meta.yaml
+++ b/{{ cookiecutter.module_name }}/meta.yaml
@@ -26,11 +26,16 @@ requirements:
     - GENERATE_RUN_REQUIREMENTS
 
 test:
-  imports:
-    - GENERATE_IMPORTS
-
   requires:
     - GENERATE_TEST_REQUIREMENTS
+  
+  source_files:
+    - tests
+
+  commands:
+    - pip check
+    - pip list
+    - pytest
 
 about:
   home: https://github.com/{{ cookiecutter.github_org }}/{{ cookiecutter.repo_name }}/

--- a/{{ cookiecutter.module_name }}/meta.yaml
+++ b/{{ cookiecutter.module_name }}/meta.yaml
@@ -28,7 +28,7 @@ requirements:
 test:
   requires:
     - GENERATE_TEST_REQUIREMENTS
-  
+
   source_files:
     - tests
 


### PR DESCRIPTION
- Added `setuptools-git-versioning >=2.0` under `host`
- Added `pip check` recommended by conda-forge reviewer to check all dependencies have no conflict
- Added `pip list` for us to check the versions of all the installed packages during the CI run
- Added `pytest` to run full unit tests sourced from PyPI
- Removed simple `imports` test since pytest assumes all packages must be imported correctly

This is the resulting default behavior tested locally:

```yml
requirements:
  build:

  host:
    - python >=3.10
    - setuptools
    - setuptools-git-versioning >=2.0
    - pip

  run:
    - python >=3.10
    - numpy

test:
  requires:
    - pip
    - pytest
  
  source_files:
    - tests

  commands:
    - pip check
    - pip list
    - pytest
```