### PR TITLE
Add comment to use matplotlib-base instead of matplotlib for conda-forge meta.yaml file

### DIFF
--- a/{{ cookiecutter.module_name }}/meta.yaml
+++ b/{{ cookiecutter.module_name }}/meta.yaml
@@ -23,6 +23,7 @@ requirements:
     - GENERATE_HOST_REQUIREMENTS
 
   run:
+    # REMOVE THIS LINE - Replace matplotlib with matplotlib-base as recommended by the linter.
     - GENERATE_RUN_REQUIREMENTS
 
 test:


### PR DESCRIPTION
Closes #24 

