### PR TITLE
Remove dashes on name/version and use PYTHON string literal

### DIFF
--- a/{{ cookiecutter.module_name }}/meta.yaml
+++ b/{{ cookiecutter.module_name }}/meta.yaml
@@ -1,5 +1,5 @@
-{{ "{%- set name =" | safe }} "{{ cookiecutter.module_name }}" {{ "-%}" | safe }}
-{{ "{%- set version =" | safe }} "{{ cookiecutter.version }}" {{ "-%}" | safe }}
+{{ "{% set name =" | safe }} "{{ cookiecutter.module_name }}" {{ "%}" | safe }}
+{{ "{% set version =" | safe }} "{{ cookiecutter.version }}" {{ "%}" | safe }}
 
 package:
   name: {{ "{{ name|lower }}" | safe }}
@@ -12,7 +12,7 @@ source:
 build:
   noarch: python
   number: 0
-  script: python -m pip install --no-deps --ignore-installed .
+  script: {{ "{{ PYTHON }}" }} -m pip install --no-deps --ignore-installed .
 
 requirements:
   build:


### PR DESCRIPTION
Closes #26 

Result:

```
{% set name = "diffpy.snmf" %}
{% set version = "1.0.0" %}

package:
  name: {{ name|lower }}
  version: {{ version }}

source:
  url: https://pypi.io/packages/source/d/diffpy_snmf/diffpy_snmf-{{ version }}.tar.gz
  sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855

build:
  noarch: python
  number: 0
  script: {{ PYTHON }} -m pip install --no-deps --ignore-installed .
```